### PR TITLE
Fix b-roll keyword timing

### DIFF
--- a/main.py
+++ b/main.py
@@ -294,10 +294,18 @@ def generate_video():
         if words:
             # Build a list of keyword b-roll triggers with exact timing
             for kw in keywords:
-                kw_lower = kw.lower()
-                for i, word_obj in enumerate(words):
-                    word_text = word_obj["text"].lower()
-                    if word_text == kw_lower:
+                kw_tokens = re.findall(r"\b\w+\b", kw.lower())
+                if not kw_tokens:
+                    continue
+                token_count = len(kw_tokens)
+                for i in range(len(words) - token_count + 1):
+                    matched = True
+                    for j, token in enumerate(kw_tokens):
+                        word_text = re.sub(r"\W+", "", str(words[i + j].get("text", "")).lower())
+                        if word_text != token:
+                            matched = False
+                            break
+                    if matched:
                         local_img_path = downloaded_broll_paths_by_kw.get(kw)
                         if not local_img_path:
                             continue
@@ -305,12 +313,26 @@ def generate_video():
                             continue
                         img_ffmpeg_idx = broll_local_path_to_ffmpeg_idx[local_img_path]
                         overlay_operations.append({
-                            "start": word_obj["start"],
-                            "end": word_obj["end"],
+                            "start": words[i]["start"],
+                            "end": words[i + token_count - 1]["end"],
                             "img_idx": img_ffmpeg_idx,
                             "keyword": kw
                         })
                         break  # Apply image b-roll only once per keyword
+
+        # Fallback: If no word-level matches, use segment text to trigger images
+        if not overlay_operations and final_processing_segments:
+            for seg in final_processing_segments:
+                for kw, local_img_path in downloaded_broll_paths_by_kw.items():
+                    if kw.lower() in seg.text.lower() and local_img_path in broll_local_path_to_ffmpeg_idx:
+                        img_ffmpeg_idx = broll_local_path_to_ffmpeg_idx[local_img_path]
+                        overlay_operations.append({
+                            "start": seg.start,
+                            "end": seg.end,
+                            "img_idx": img_ffmpeg_idx,
+                            "keyword": kw
+                        })
+                        break
         
         overlay_operations.sort(key=lambda op: op["start"])  # Ensure ordered
 
@@ -340,7 +362,16 @@ def generate_video():
         # B-roll Video Overlays
         broll_video_overlay_counter = 0
         for config_item in broll_video_config:
+            # Support both "segment_index" (snake_case) and "segmentIndex" (camelCase)
             segment_idx = config_item.get("segment_index")
+            if segment_idx is None:
+                segment_idx = config_item.get("segmentIndex")
+
+            try:
+                segment_idx = int(segment_idx) if segment_idx is not None else None
+            except (TypeError, ValueError):
+                segment_idx = None
+
             original_filename = None
 
             # Robust filename extraction


### PR DESCRIPTION
## Summary
- enhance keyword detection logic to support multi-word phrases using word-level timestamps
- keep segment-based fallback when no word matches are found

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6885ba46088c8333ba2b960424ab15ff