### PR TITLE
Fix b-roll keyword timing

### DIFF
--- a/main.py
+++ b/main.py
@@ -248,15 +248,14 @@ def generate_video():
         all_input_file_paths_ordered = [ffmpeg_input_path] # Main video is 0
 
         # --- B-roll Image Preparation ---
-        downloaded_broll_paths_by_kw = {} # Renamed from broll_paths for clarity in this scope
-        for kw, url in broll_images.items(): # broll_images from request: kw -> url
+        downloaded_broll_paths_by_kw = {}
+        for kw, url in broll_images.items():
             if url:
                 img_filename = f"{uuid.uuid4().hex}_{secure_filename(kw)}.jpg"
                 local_img_path = os.path.join(tempfile.gettempdir(), img_filename)
-                # Add to cleanup list as soon as path is determined, before download attempt
                 temp_files_to_clean_up.append(local_img_path)
                 if download_image(url, local_img_path):
-                    downloaded_broll_paths_by_kw[kw] = local_img_path
+                    downloaded_broll_paths_by_kw[kw.lower()] = local_img_path
         
         # The line below was moved into the loop above to prevent NameError
         # temp_files_to_clean_up.append(local_img_path) 
@@ -312,7 +311,8 @@ def generate_video():
                             matched = False
                             break
                     if matched:
-                        local_img_path = downloaded_broll_paths_by_kw.get(kw)
+                        kw_lower = kw.lower()
+                        local_img_path = downloaded_broll_paths_by_kw.get(kw_lower)
                         if not local_img_path:
                             continue
                         if local_img_path not in broll_local_path_to_ffmpeg_idx:
@@ -324,7 +324,6 @@ def generate_video():
                             "img_idx": img_ffmpeg_idx,
                             "keyword": kw
                         })
-                        break  # Apply image b-roll only once per keyword
 
         # Fallback: If no word-level matches, use segment text to trigger images
         if not overlay_operations and final_processing_segments:

--- a/main.py
+++ b/main.py
@@ -441,6 +441,7 @@ def generate_video():
             "-crf", "23",
             "-c:a", "aac",
             "-b:a", "192k",
+            "-shortest",
             ffmpeg_output_path
         ]
         app.logger.info(f"FFmpeg command: {' '.join(ffmpeg_cmd)}")

--- a/main.py
+++ b/main.py
@@ -294,10 +294,18 @@ def generate_video():
         if words:
             # Build a list of keyword b-roll triggers with exact timing
             for kw in keywords:
-                kw_lower = kw.lower()
-                for i, word_obj in enumerate(words):
-                    word_text = word_obj["text"].lower()
-                    if word_text == kw_lower:
+                kw_tokens = re.findall(r"\b\w+\b", kw.lower())
+                if not kw_tokens:
+                    continue
+                token_count = len(kw_tokens)
+                for i in range(len(words) - token_count + 1):
+                    matched = True
+                    for j, token in enumerate(kw_tokens):
+                        word_text = re.sub(r"\W+", "", str(words[i + j].get("text", "")).lower())
+                        if word_text != token:
+                            matched = False
+                            break
+                    if matched:
                         local_img_path = downloaded_broll_paths_by_kw.get(kw)
                         if not local_img_path:
                             continue
@@ -305,12 +313,26 @@ def generate_video():
                             continue
                         img_ffmpeg_idx = broll_local_path_to_ffmpeg_idx[local_img_path]
                         overlay_operations.append({
-                            "start": word_obj["start"],
-                            "end": word_obj["end"],
+                            "start": words[i]["start"],
+                            "end": words[i + token_count - 1]["end"],
                             "img_idx": img_ffmpeg_idx,
                             "keyword": kw
                         })
                         break  # Apply image b-roll only once per keyword
+
+        # Fallback: If no word-level matches, use segment text to trigger images
+        if not overlay_operations and final_processing_segments:
+            for seg in final_processing_segments:
+                for kw, local_img_path in downloaded_broll_paths_by_kw.items():
+                    if kw.lower() in seg.text.lower() and local_img_path in broll_local_path_to_ffmpeg_idx:
+                        img_ffmpeg_idx = broll_local_path_to_ffmpeg_idx[local_img_path]
+                        overlay_operations.append({
+                            "start": seg.start,
+                            "end": seg.end,
+                            "img_idx": img_ffmpeg_idx,
+                            "keyword": kw
+                        })
+                        break
         
         overlay_operations.sort(key=lambda op: op["start"])  # Ensure ordered
 
@@ -340,7 +362,16 @@ def generate_video():
         # B-roll Video Overlays
         broll_video_overlay_counter = 0
         for config_item in broll_video_config:
+            # Support both "segment_index" (snake_case) and "segmentIndex" (camelCase)
             segment_idx = config_item.get("segment_index")
+            if segment_idx is None:
+                segment_idx = config_item.get("segmentIndex")
+
+            try:
+                segment_idx = int(segment_idx) if segment_idx is not None else None
+            except (TypeError, ValueError):
+                segment_idx = None
+
             original_filename = None
 
             # Robust filename extraction

--- a/main.py
+++ b/main.py
@@ -261,7 +261,9 @@ def generate_video():
 
         unique_local_image_paths = sorted(list(set(downloaded_broll_paths_by_kw.values())))
         for local_path in unique_local_image_paths:
-            ffmpeg_additional_inputs.extend(["-i", local_path.replace('\\', '/')])
+            ffmpeg_additional_inputs.extend([
+                "-loop", "1", "-i", local_path.replace('\\', '/')
+            ])
             all_input_file_paths_ordered.append(local_path)
             broll_local_path_to_ffmpeg_idx[local_path] = len(all_input_file_paths_ordered) - 1
 

--- a/main.py
+++ b/main.py
@@ -132,6 +132,10 @@ def generate_video():
     output_width_req = request.form.get('output_width', type=int)
     output_height_req = request.form.get('output_height', type=int)
 
+    if not shutil.which("ffmpeg"):
+        app.logger.error("ffmpeg not found. Please install ffmpeg to generate videos.")
+        return jsonify({"error": "ffmpeg not installed"}), 500
+
 
     if not transcript_text_from_form and not transcribed_segments_json:
         return jsonify({"error": "Transcript required"}), 400


### PR DESCRIPTION
## Summary
- enhance keyword detection logic to support multi-word phrases using word-level timestamps
- keep segment-based fallback when no word matches are found

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6885ba46088c8333ba2b960424ab15ff